### PR TITLE
more settings fixes

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -71,7 +71,7 @@ TEMPLATES = [
     },
 ]
 
-WSGI_APPLICATION = 'habit_tracker.wsgi.application'
+WSGI_APPLICATION = 'config.wsgi.application'
 
 
 # Database


### PR DESCRIPTION
there was one more spot in the settings.py file that pointed to the wrong name ('habit_tracker' instead of 'config')